### PR TITLE
Add `windows-2025` runner

### DIFF
--- a/.github/workflows/e2e-runners.yml
+++ b/.github/workflows/e2e-runners.yml
@@ -9,6 +9,7 @@ jobs:
         runner:
           - ubuntu-22.04
           - ubuntu-20.04
+          - windows-2025
           - windows-2019
           - macos-15
           - macos-13

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ with small patches to fix minor problems.
         <th rowspan="3">Linux</th>
         <!-- &zwj; U+200D ZERO WIDTH JOINER -->
         <td><code>ubuntu-&zwj;24.04</code>*</td>
-        <td rowspan="5">
+        <td rowspan="6">
 
 `2008`&ndash;`2024`
 
@@ -321,9 +321,10 @@ with small patches to fix minor problems.
       <tr><td><code>ubuntu-22.04</code></td></tr>
       <tr><td><code>ubuntu-20.04</code></td></tr>
       <tr>
-        <th rowspan="2">Windows</th>
-        <td><code>windows-2022</code>*</td>
+        <th rowspan="3">Windows</th>
+        <td><code>windows-2025</code></td>
       </tr>
+      <tr><td><code>windows-2022</code>*</td></tr>
       <tr><td><code>windows-2019</code></td></tr>
       <tr>
         <th rowspan="3">macOS</th>


### PR DESCRIPTION
See
- https://github.blog/changelog/2024-12-19-windows-server-2025-is-now-in-public-preview/
- https://github.com/actions/runner-images?tab=readme-ov-file#available-images

PS: "Public Preview" is the new terminology for "(Limited) Public Beta", starting on 18, 2024. See this [GitHub blog](https://github.blog/changelog/2024-10-18-new-terminology-for-github-previews/) post.