### PR TITLE
feat: add support for TeX Live 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ with small patches to fix minor problems.
         <td><code>ubuntu-&zwj;24.04</code>*</td>
         <td rowspan="5">
 
-`2008`&ndash;`2024`
+`2008`&ndash;`2025`
 
 </td>
       </tr>
@@ -330,7 +330,7 @@ with small patches to fix minor problems.
         <td><code>macos-15</code></td>
         <td rowspan="3">
 
-`2013`&ndash;`2024`
+`2013`&ndash;`2025`
 
 > :memo:&ensp;Versions prior to `2013` are for 32-bit systems and
 > will not work due to _<q>Bad CPU type in executable.</q>_
@@ -371,7 +371,7 @@ All inputs are optional.
 | `texdir`              | String | TeX Live system installation directory. This has the same effect as the installer's [`-texdir`] option and takes precedence over the `prefix` input and related environment variables.                                   |
 | `tlcontrib`           | Bool   | <p>Set up [TLContrib] as an additional TeX package repository. This input will be ignored for older versions.</p> **Default:**&ensp;`false`                                                                              |
 | `update-all-packages` | Bool   | <p>Update all TeX packages when cache restored. Defaults to `false`, and the action will update only `tlmgr`.</p> **Default:**&ensp;`false`                                                                              |
-| `version`             | String | <p>TeX Live version to install. Supported values are `2008` to `2024`, and `latest`.</p> **Default:**&ensp;`latest` if the `repository` input is not set, otherwise the remote version will be assumed.                  |
+| `version`             | String | <p>TeX Live version to install. Supported values are `2008` to `2025`, and `latest`.</p> **Default:**&ensp;`latest` if the `repository` input is not set, otherwise the remote version will be assumed.                  |
 
 <!-- TODO
   - Provide a separate subsection on the input syntax and file format.

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ inputs:
   version:
     description: >-
       TeX Live version to install.
-      Supported values are `2008` to `2024`, and `latest`.
+      Supported values are `2008` to `2025`, and `latest`.
     required: false
 outputs:
   cache-hit:

--- a/packages/action/__snapshots__/cache.test.ts.snap
+++ b/packages/action/__snapshots__/cache.test.ts.snap
@@ -4,7 +4,7 @@ exports[`ActionsCacheService > @@dispose > does not set \`target\` (primary) 1`]
 [
   "CACHE",
   {
-    "key": "setup-texlive-action-linux-<arch>-2024-4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+    "key": "setup-texlive-action-linux-<arch>-2025-4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
   },
 ]
 `;
@@ -13,7 +13,7 @@ exports[`ActionsCacheService > @@dispose > does not set \`target\` (unique) 1`] 
 [
   "CACHE",
   {
-    "key": "setup-texlive-action-linux-<arch>-2024-4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945-<random_string>",
+    "key": "setup-texlive-action-linux-<arch>-2025-4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945-<random_string>",
   },
 ]
 `;
@@ -22,7 +22,7 @@ exports[`ActionsCacheService > @@dispose > sets \`target\` (fail) 1`] = `
 [
   "CACHE",
   {
-    "key": "setup-texlive-action-linux-<arch>-2024-4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+    "key": "setup-texlive-action-linux-<arch>-2025-4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
     "target": "<TEXDIR>",
   },
 ]
@@ -32,7 +32,7 @@ exports[`ActionsCacheService > @@dispose > sets \`target\` (none) 1`] = `
 [
   "CACHE",
   {
-    "key": "setup-texlive-action-linux-<arch>-2024-4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+    "key": "setup-texlive-action-linux-<arch>-2025-4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
     "target": "<TEXDIR>",
   },
 ]
@@ -42,7 +42,7 @@ exports[`ActionsCacheService > @@dispose > sets \`target\` (oldprimary) 1`] = `
 [
   "CACHE",
   {
-    "key": "setup-texlive-action-linux-<arch>-2024-4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945-<random_string>",
+    "key": "setup-texlive-action-linux-<arch>-2025-4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945-<random_string>",
     "target": "<TEXDIR>",
   },
 ]
@@ -52,7 +52,7 @@ exports[`ActionsCacheService > @@dispose > sets \`target\` (oldsecondary) 1`] = 
 [
   "CACHE",
   {
-    "key": "setup-texlive-action-linux-<arch>-2024-4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+    "key": "setup-texlive-action-linux-<arch>-2025-4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
     "target": "<TEXDIR>",
   },
 ]
@@ -62,7 +62,7 @@ exports[`ActionsCacheService > @@dispose > sets \`target\` (oldunique) 1`] = `
 [
   "CACHE",
   {
-    "key": "setup-texlive-action-linux-<arch>-2024-4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945-<random_string>}",
+    "key": "setup-texlive-action-linux-<arch>-2025-4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945-<random_string>}",
   },
 ]
 `;
@@ -71,7 +71,7 @@ exports[`ActionsCacheService > @@dispose > sets \`target\` (secondary) 1`] = `
 [
   "CACHE",
   {
-    "key": "setup-texlive-action-linux-<arch>-2024-4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+    "key": "setup-texlive-action-linux-<arch>-2025-4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
     "target": "<TEXDIR>",
   },
 ]
@@ -82,12 +82,12 @@ exports[`ActionsCacheService > restore > restores cache 1`] = `
   [
     "<TEXDIR>",
   ],
-  "setup-texlive-action-linux-<arch>-2024-4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945-<random_string>",
+  "setup-texlive-action-linux-<arch>-2025-4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945-<random_string>",
   [
-    "setup-texlive-action-linux-<arch>-2024-4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
-    "setup-texlive-linux-<arch>-2024-4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
-    "setup-texlive-action-linux-<arch>-2024-",
-    "setup-texlive-linux-<arch>-2024-",
+    "setup-texlive-action-linux-<arch>-2025-4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+    "setup-texlive-linux-<arch>-2025-4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+    "setup-texlive-action-linux-<arch>-2025-",
+    "setup-texlive-linux-<arch>-2025-",
   ],
 ]
 `;
@@ -97,12 +97,12 @@ exports[`ActionsCacheService > restore > restores cache 2`] = `
   [
     "<TEXDIR>",
   ],
-  "setup-texlive-action-linux-<arch>-2024-cc603f9d1b6fb8568f57853e4936e2604c5eb12ad31ad1908a08b32a04e38656-<random_string>",
+  "setup-texlive-action-linux-<arch>-2025-cc603f9d1b6fb8568f57853e4936e2604c5eb12ad31ad1908a08b32a04e38656-<random_string>",
   [
-    "setup-texlive-action-linux-<arch>-2024-cc603f9d1b6fb8568f57853e4936e2604c5eb12ad31ad1908a08b32a04e38656",
-    "setup-texlive-linux-<arch>-2024-cc603f9d1b6fb8568f57853e4936e2604c5eb12ad31ad1908a08b32a04e38656",
-    "setup-texlive-action-linux-<arch>-2024-",
-    "setup-texlive-linux-<arch>-2024-",
+    "setup-texlive-action-linux-<arch>-2025-cc603f9d1b6fb8568f57853e4936e2604c5eb12ad31ad1908a08b32a04e38656",
+    "setup-texlive-linux-<arch>-2025-cc603f9d1b6fb8568f57853e4936e2604c5eb12ad31ad1908a08b32a04e38656",
+    "setup-texlive-action-linux-<arch>-2025-",
+    "setup-texlive-linux-<arch>-2025-",
   ],
 ]
 `;

--- a/packages/action/__tests__/runs/main/update.test.ts
+++ b/packages/action/__tests__/runs/main/update.test.ts
@@ -62,7 +62,7 @@ it('removes tlcontrib', async () => {
     yield { tag: 'main', path: MOCK_URL };
     yield { tag: 'tlcontrib', path: MOCK_URL };
   });
-  const opts = { version: '2023' } as const;
+  const opts = { version: '2024' } as const;
   await expect(update(opts)).resolves.not.toThrow();
   expect(remove).toHaveBeenCalledWith('tlcontrib');
 });

--- a/packages/data/data/texlive-versions.json
+++ b/packages/data/data/texlive-versions.json
@@ -1,15 +1,15 @@
 {
   "$schema": "../schemas/texlive-versions.schema.json",
   "previous": {
-    "version": "2023",
-    "releaseDate": "2023-03-19T21:25:25Z"
-  },
-  "current": {
     "version": "2024",
     "releaseDate": "2024-03-13T17:37:00Z"
   },
-  "next": {
+  "current": {
     "version": "2025",
-    "releaseDate": "2025-03-08"
+    "releaseDate": "2025-03-08T17:37:00Z"
+  },
+  "next": {
+    "version": "2026",
+    "releaseDate": "2026-03-07"
   }
 }

--- a/packages/e2e/workflows/fallback-to-historic-master.yml
+++ b/packages/e2e/workflows/fallback-to-historic-master.yml
@@ -8,7 +8,7 @@ jobs:
         id: setup
         uses: ./
         with:
-          version: 2023
+          version: 2024
       - if: fromJSON(steps.setup.outputs.cache-restored)
         run: exit 1
       - run: >-
@@ -25,7 +25,7 @@ jobs:
         id: setup
         uses: ./
         with:
-          version: 2023
+          version: 2024
       - if: ${{ !fromJSON(steps.setup.outputs.cache-hit) }}
         run: exit 1
       - run: >-

--- a/packages/e2e/workflows/move-to-historic.yml
+++ b/packages/e2e/workflows/move-to-historic.yml
@@ -8,7 +8,7 @@ jobs:
         id: setup
         uses: ./
         with:
-          version: 2023
+          version: 2024
       - if: fromJSON(steps.setup.outputs.cache-restored)
         run: exit 1
       - run: |
@@ -23,6 +23,6 @@ jobs:
         id: setup
         uses: ./
         with:
-          version: 2023
+          version: 2024
       - if: ${{ !fromJSON(steps.setup.outputs.cache-hit) }}
         run: exit 1

--- a/packages/e2e/workflows/tlpretest.yml
+++ b/packages/e2e/workflows/tlpretest.yml
@@ -8,5 +8,5 @@ jobs:
         uses: ./
         with:
           repository: https://ftp.math.utah.edu/pub/tlpretest/
-          version: 2025
+          version: 2026
       - run: tlmgr version

--- a/packages/texlive/__snapshots__/install-tl/profile.test.ts.snap
+++ b/packages/texlive/__snapshots__/install-tl/profile.test.ts.snap
@@ -571,3 +571,38 @@ tlpdbopt_desktop_integration 0
 tlpdbopt_file_assocs 0
 tlpdbopt_w32_multi_user 0
 `;
+
+exports[`2025 > linux > texlive.profile 1`] = `
+TEXDIR $RUNNER_TEMP/setup-texlive-action/2025
+TEXMFLOCAL $RUNNER_TEMP/setup-texlive-action/texmf-local
+TEXMFSYSCONFIG $RUNNER_TEMP/setup-texlive-action/2025/texmf-config
+TEXMFSYSVAR $RUNNER_TEMP/setup-texlive-action/2025/texmf-var
+TEXMFHOME $RUNNER_TEMP/setup-texlive-action/texmf-local
+TEXMFCONFIG $RUNNER_TEMP/setup-texlive-action/2025/texmf-config
+TEXMFVAR $RUNNER_TEMP/setup-texlive-action/2025/texmf-var
+selected_scheme scheme-infraonly
+instopt_adjustpath 0
+instopt_adjustrepo 0
+tlpdbopt_autobackup 0
+tlpdbopt_install_docfiles 0
+tlpdbopt_install_srcfiles 0
+`;
+
+exports[`2025 > win32 > texlive.profile 1`] = `
+TEXDIR $RUNNER_TEMP\\setup-texlive-action\\2025
+TEXMFLOCAL $RUNNER_TEMP\\setup-texlive-action\\texmf-local
+TEXMFSYSCONFIG $RUNNER_TEMP\\setup-texlive-action\\2025\\texmf-config
+TEXMFSYSVAR $RUNNER_TEMP\\setup-texlive-action\\2025\\texmf-var
+TEXMFHOME $RUNNER_TEMP\\setup-texlive-action\\texmf-local
+TEXMFCONFIG $RUNNER_TEMP\\setup-texlive-action\\2025\\texmf-config
+TEXMFVAR $RUNNER_TEMP\\setup-texlive-action\\2025\\texmf-var
+selected_scheme scheme-infraonly
+instopt_adjustpath 0
+instopt_adjustrepo 0
+tlpdbopt_autobackup 0
+tlpdbopt_install_docfiles 0
+tlpdbopt_install_srcfiles 0
+tlpdbopt_desktop_integration 0
+tlpdbopt_file_assocs 0
+tlpdbopt_w32_multi_user 0
+`;

--- a/packages/texlive/__tests__/releases.test.ts
+++ b/packages/texlive/__tests__/releases.test.ts
@@ -55,7 +55,7 @@ describe('ReleaseData.setup', () => {
     vi.spyOn(Temporal.Now, 'instant').mockReturnValueOnce(
       Temporal
         .PlainDateTime
-        .from('2025-03-08')
+        .from('2026-03-07')
         .toZonedDateTime('UTC')
         .toInstant(),
     );


### PR DESCRIPTION
TeX Live 2025 was released on 8 March 2025, see https://www.tug.org/texlive/.

This PR is an emulation of
- #291.

Wish I caught all cases.